### PR TITLE
Restructure site into Mithahara umbrella brand, redesign, add real apps + SEO

### DIFF
--- a/data.js
+++ b/data.js
@@ -37,6 +37,37 @@ export const contacts = {
   website: "www.mithahara.com"
 };
 
+export const apps = [
+  {
+    name: "BYOK Gateway",
+    platform: "Odoo",
+    tagline: "Your own AI account, powering Odoo's AI writing assistant",
+    description: "Redirects Odoo's AI writing tools to your own OpenAI, Anthropic, or OpenRouter API key instead of Odoo's metered service, with explicit user consent and graceful fallback.",
+    url: "https://apps.odoo.com/apps/modules/19.0/mh_llm_gateway"
+  },
+  {
+    name: "Community Cash Reconciler",
+    platform: "Odoo",
+    tagline: "From an unreconciled bank line to matched invoices, in one click",
+    description: "Adds a missing Community Edition screen for matching bank deposits to open invoices, including lump-sum deposits spanning multiple customers and short payments.",
+    url: "https://apps.odoo.com/apps/modules/19.0/mh_cash_application_matcher"
+  },
+  {
+    name: "Multi-Currency Rounding",
+    platform: "Odoo",
+    tagline: "Stop sub-cent rounding noise from hiding inside your FX gain/loss",
+    description: "Lets you set a rounding threshold and dedicated account for small multi-currency reconciliation residuals, keeping real exchange gain/loss clean.",
+    url: "https://apps.odoo.com/apps/modules/19.0/mh_currency_rounding_tool"
+  },
+  {
+    name: "ClipMark",
+    platform: "Chrome",
+    tagline: "YouTube notes and flashcards that quiz you back",
+    description: "Bookmark moments in YouTube videos, turn them into spaced-repetition flashcards with on-device AI notes, and export to Anki.",
+    url: "https://chromewebstore.google.com/detail/clipmark-youtube-notes-fl/iboippnihpcnnglgboaiedaiimbiolgg"
+  }
+];
+
 export const notifications = [
   "We are currently on monsoon break. We will be back once the weather settles.",
 ];

--- a/data.js
+++ b/data.js
@@ -32,7 +32,6 @@ export const menu = [
 
 export const contacts = {
   whatsapp: "https://whatsapp.com/channel/0029Vb6KjsJ1SWt2pEDw5f1z",
-  phone: ["728-200-2674", "789-589-9800"],
   address: "Opposite Saanwara Sweets, Sec - 14, Panchkula, HR - 134103",
   email: "founder@mithahara.com",
   website: "www.mithahara.com"
@@ -44,8 +43,8 @@ export const notifications = [
 
 export const faqs = [
   {
-    question: "What is Mithahara?",
-    answer: "Mithahara serves healthy, hygienic, sustainable vegetarian food with eco-friendly plating. Our menu features fresh plates like Appam, Idli, Uttapam, Paranthas, and more, prepared daily."
+    question: "What is Ahar?",
+    answer: "Ahar is Mithahara's vegetarian food venture — healthy, hygienic, sustainable vegetarian food with eco-friendly plating. Our menu features fresh plates like Appam, Idli, Uttapam, Paranthas, and more, prepared daily."
   },
   {
     question: "Since when are you serving?",

--- a/index.html
+++ b/index.html
@@ -5,13 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mithahara - Healthy, Hygienic & Sustainable</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  
-  <!-- Font Awesome icons -->
-  <link
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-    crossorigin="anonymous"
-  />
 </head>
 <body>
   <div id="app">
@@ -19,11 +12,12 @@
     <nav class="navbar">
       <div class="nav-container">
         <h1 class="nav-title">Mithahara</h1>
-        <div class="nav-actions">
-          <button class="theme-toggle" aria-label="Toggle theme">
-            <i class="fas fa-moon"></i>
-          </button>
-        </div>
+        <ul class="nav-links">
+          <li><a href="#ahar">Ahar</a></li>
+          <li><a href="#mansahara">Man'sahara</a></li>
+          <li><a href="#apps">Apps</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
       </div>
     </nav>
 
@@ -32,56 +26,88 @@
       <!-- Hero Section -->
       <section class="hero-section">
         <div class="hero-container">
-          <h1 class="hero-title">Mithahara</h1>
-          <p class="hero-subtitle">HEALTHY, HYGIENIC & SUSTAINABLE</p>
-          <p class="hero-description">Serving fresh vegetarian food with eco-friendly plating</p>
-          <div class="hero-actions">
-            <a class="cta-button primary" href="#menu">
-              View Menu <i class="fas fa-utensils"></i>
-            </a>
-            <a class="cta-button secondary" href="#contact">
-              Contact Us <i class="fas fa-phone"></i>
-            </a>
+          <div class="hero-copy">
+            <span class="log-tag">log/000 — Panchkula</span>
+            <h1 class="hero-title">Mithahara</h1>
+            <p class="hero-subtitle">Healthy, Hygienic & Sustainable, Every Day</p>
+            <p class="hero-description">Building sustainable ways to hit your daily dietary goals — through food ventures and the software that supports them.</p>
+            <div class="hero-actions">
+              <a class="cta-button primary" href="#ahar">Ahar</a>
+              <a class="cta-button secondary" href="#mansahara">Man'sahara</a>
+              <a class="cta-button secondary" href="#apps">Apps</a>
+            </div>
           </div>
-        </div>
-        
-        <!-- Floating elements for visual appeal -->
-        <div class="floating-elements">
-          <div class="floating-element" style="--delay: 0s"></div>
-          <div class="floating-element" style="--delay: 1s"></div>
-          <div class="floating-element" style="--delay: 2s"></div>
-          <div class="floating-element" style="--delay: 3s"></div>
+          <div class="hero-cards">
+            <a class="venture-card" href="#ahar"><span>Ahar</span><span class="log-tag">Active</span></a>
+            <a class="venture-card upcoming" href="#mansahara"><span>Man'sahara</span><span class="log-tag gold">Coming Soon</span></a>
+            <a class="venture-card" href="#apps"><span>Apps</span><span class="log-tag">Shipping</span></a>
+          </div>
         </div>
       </section>
 
-      <!-- Menu Section -->
-      <section class="menu-section" id="menu">
+      <!-- Ahar Section (vegetarian food, active) -->
+      <section class="venture-section" id="ahar">
         <div class="container">
-          <h2 class="section-title">OUR MENU</h2>
-          <p class="menu-tagline">SERVING FRESH FROM 7 AM TO 2:30 PM</p>
+          <div class="log-row"><span class="log-tag">log/001 — Active</span></div>
+          <h2 class="section-title">Ahar</h2>
+          <p class="venture-tagline">Mithahara's Vegetarian Venture · Serving 7:00–14:30 Daily</p>
+
           <div class="menu-grid" id="menu-grid">
             <!-- Menu items will be populated by JavaScript -->
           </div>
-        </div>
-      </section>
 
-      <!-- Contact Section -->
-      <section class="contact-section" id="contact">
-        <div class="container">
-          <h2 class="section-title">Contact Details</h2>
-          <div class="contact-grid" id="contact-grid">
-            <!-- Contact details will be populated by JavaScript -->
+          <div class="ahar-details">
+            <div>
+              <h3 class="subsection-title">Frequently Asked</h3>
+              <div class="faq-list" id="faq-list">
+                <!-- FAQ items will be populated by JavaScript -->
+              </div>
+            </div>
+            <div>
+              <h3 class="subsection-title" id="contact">Contact</h3>
+              <div class="contact-grid" id="contact-grid">
+                <!-- Contact details will be populated by JavaScript -->
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <!-- FAQ Section -->
-      <section class="faq-section">
+      <!-- Man'sahara Section (non-vegetarian food, upcoming) -->
+      <section class="venture-section teaser-section" id="mansahara">
+        <span class="teaser-watermark">log/002</span>
         <div class="container">
-          <h2 class="section-title">Frequently Asked Questions</h2>
-          <div class="faq-list" id="faq-list">
-            <!-- FAQ items will be populated by JavaScript -->
+          <div class="log-row"><span class="log-tag gold">log/002 — Coming Soon</span></div>
+          <h2 class="section-title">Man'sahara</h2>
+          <p class="venture-tagline">Mithahara's Non-Vegetarian Venture</p>
+          <p class="venture-description">
+            Same mission as Ahar — hitting your daily dietary goals sustainably, healthily, and hygienically —
+            now for non-vegetarian food. We're getting it ready. Check back soon.
+          </p>
+        </div>
+      </section>
+
+      <!-- Apps Section (Chrome extensions + Odoo apps) -->
+      <section class="venture-section apps-section" id="apps">
+        <div class="container">
+          <div class="log-row"><span class="log-tag">log/003 — Shipping</span></div>
+          <h2 class="section-title">Apps</h2>
+          <p class="venture-tagline">Chrome Extensions & Odoo Apps, Built at Mithahara</p>
+          <p class="venture-description">
+            Alongside our food ventures, we build and ship Chrome extensions and Odoo apps at a fast pace.
+            New products land regularly — this section will list them as they go live.
+          </p>
+          <div class="apps-slots">
+            <div class="app-slot"><span>chrome-ext</span><span class="slot-label">next release</span></div>
+            <div class="app-slot"><span>odoo-app</span><span class="slot-label">next release</span></div>
+            <div class="app-slot"><span>chrome-ext</span><span class="slot-label">next release</span></div>
           </div>
+          <div class="hero-actions" style="justify-content: center;">
+            <a class="cta-button primary" href="https://www.odoo.com/r/aff-mithahara" target="_blank" rel="noopener noreferrer">
+              › Explore Odoo Apps
+            </a>
+          </div>
+          <p class="affiliate-disclosure">The Odoo link above is an affiliate link.</p>
         </div>
       </section>
 
@@ -89,10 +115,10 @@
       <section class="cta-section">
         <div class="container">
           <div class="cta-content">
-            <h2 class="cta-title">Order Fresh & Healthy Food Today!</h2>
-            <p class="cta-description">Experience the taste of healthy, hygienic, and sustainable vegetarian cuisine</p>
-            <a class="cta-button large" href="mailto:founder@mithahara.com">
-              Contact Us <i class="fas fa-envelope"></i>
+            <h2 class="cta-title">One Mission, A Few Ways to Live It</h2>
+            <p class="cta-description">Explore Ahar, look out for Man'sahara, and power your workflow with our apps</p>
+            <a class="cta-button large primary" href="mailto:founder@mithahara.com">
+              Contact Us
             </a>
           </div>
         </div>
@@ -105,32 +131,30 @@
         <div class="footer-content">
           <div class="footer-section">
             <h3 class="footer-title">Mithahara</h3>
-            <p class="footer-description">Empowering wellness through technology and community.</p>
+            <p class="footer-description">Sustainable, healthy, hygienic daily nutrition — through food ventures and the software that supports them.</p>
           </div>
-          
+
           <div class="footer-section">
-            <h4 class="footer-subtitle">Quick Links</h4>
+            <h4 class="footer-subtitle">Ventures</h4>
             <ul class="footer-links">
-              <li><a href="#about">About</a></li>
-              <li><a href="#features">Features</a></li>
+              <li><a href="#ahar">Ahar</a></li>
+              <li><a href="#mansahara">Man'sahara</a></li>
+              <li><a href="#apps">Apps</a></li>
               <li><a href="#contact">Contact</a></li>
-              <li><a href="#privacy">Privacy</a></li>
             </ul>
           </div>
-          
+
           <div class="footer-section">
-            <h4 class="footer-subtitle">Follow Us</h4>
+            <h4 class="footer-subtitle">Follow</h4>
             <div class="social-links">
-              <a href="#" aria-label="Facebook"><i class="fab fa-facebook"></i></a>
-              <a href="#" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
-              <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
-              <a href="#" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+              <a href="#">Facebook</a>
+              <a href="#">Instagram</a>
             </div>
           </div>
         </div>
-        
+
         <div class="footer-bottom">
-          <p>&copy; 2025 Mithahara. All rights reserved.</p>
+          <p>© 2025 Mithahara. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,75 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Mithahara - Healthy, Hygienic & Sustainable</title>
+  <title>Mithahara — Ahar Food, Man'sahara & Odoo/Chrome Apps</title>
+  <meta name="description" content="Mithahara: Ahar's fresh vegetarian food in Panchkula, the upcoming Man'sahara venture, and Odoo apps & Chrome extensions we've built — BYOK Gateway, Community Cash Reconciler, Multi-Currency Rounding, and ClipMark.">
+  <link rel="canonical" href="https://mithahara.com/">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Mithahara">
+  <meta property="og:title" content="Mithahara — Ahar Food, Man'sahara & Odoo/Chrome Apps">
+  <meta property="og:description" content="Ahar's fresh vegetarian food, the upcoming Man'sahara venture, and Mithahara's Odoo apps & Chrome extensions — BYOK Gateway, Community Cash Reconciler, Multi-Currency Rounding, and ClipMark.">
+  <meta property="og:url" content="https://mithahara.com/">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Mithahara — Ahar Food, Man'sahara & Odoo/Chrome Apps">
+  <meta name="twitter:description" content="Ahar's fresh vegetarian food, the upcoming Man'sahara venture, and Mithahara's Odoo apps & Chrome extensions.">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://mithahara.com/#organization",
+        "name": "Mithahara",
+        "url": "https://mithahara.com/",
+        "email": "founder@mithahara.com"
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "BYOK Gateway",
+        "url": "https://mithahara.com/#apps",
+        "downloadUrl": "https://apps.odoo.com/apps/modules/19.0/mh_llm_gateway",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Odoo 19",
+        "description": "Redirects Odoo's AI writing tools to your own OpenAI, Anthropic, or OpenRouter API key instead of Odoo's metered service.",
+        "creator": { "@id": "https://mithahara.com/#organization" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "Community Cash Reconciler",
+        "url": "https://mithahara.com/#apps",
+        "downloadUrl": "https://apps.odoo.com/apps/modules/19.0/mh_cash_application_matcher",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Odoo 19",
+        "description": "Adds a Community Edition screen for matching bank deposits to open invoices, including lump-sum deposits and short payments.",
+        "creator": { "@id": "https://mithahara.com/#organization" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "Multi-Currency Rounding",
+        "url": "https://mithahara.com/#apps",
+        "downloadUrl": "https://apps.odoo.com/apps/modules/19.0/mh_currency_rounding_tool",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Odoo 19",
+        "description": "Lets you set a rounding threshold and dedicated account for small multi-currency reconciliation residuals.",
+        "creator": { "@id": "https://mithahara.com/#organization" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "ClipMark",
+        "url": "https://mithahara.com/#apps",
+        "downloadUrl": "https://chromewebstore.google.com/detail/clipmark-youtube-notes-fl/iboippnihpcnnglgboaiedaiimbiolgg",
+        "applicationCategory": "BrowserApplication",
+        "operatingSystem": "Chrome",
+        "description": "Turns YouTube moments into spaced-repetition flashcards with on-device AI notes and Anki export.",
+        "creator": { "@id": "https://mithahara.com/#organization" }
+      }
+    ]
+  }
+  </script>
 </head>
 <body>
   <div id="app">
@@ -95,12 +162,10 @@
           <p class="venture-tagline">Chrome Extensions & Odoo Apps, Built at Mithahara</p>
           <p class="venture-description">
             Alongside our food ventures, we build and ship Chrome extensions and Odoo apps at a fast pace.
-            New products land regularly — this section will list them as they go live.
+            Here's what's live so far.
           </p>
-          <div class="apps-slots">
-            <div class="app-slot"><span>chrome-ext</span><span class="slot-label">next release</span></div>
-            <div class="app-slot"><span>odoo-app</span><span class="slot-label">next release</span></div>
-            <div class="app-slot"><span>chrome-ext</span><span class="slot-label">next release</span></div>
+          <div class="apps-grid" id="apps-grid">
+            <!-- App cards will be populated by JavaScript -->
           </div>
           <div class="hero-actions" style="justify-content: center;">
             <a class="cta-button primary" href="https://www.odoo.com/r/aff-mithahara" target="_blank" rel="noopener noreferrer">

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 import './style.css';
-import { menu, contacts, faqs } from './data.js';
+import { menu, contacts, faqs, apps } from './data.js';
 
 class MithaharaApp {
   constructor() {
@@ -7,6 +7,7 @@ class MithaharaApp {
     this.renderMenu();
     this.renderContacts();
     this.renderFAQ();
+    this.renderApps();
     this.setupEventListeners();
   }
 
@@ -61,6 +62,21 @@ class MithaharaApp {
           <p>${faq.answer}</p>
         </div>
       </div>
+    `).join('');
+  }
+
+  renderApps() {
+    const appsGrid = document.querySelector('.apps-grid');
+    if (!appsGrid) return;
+
+    appsGrid.innerHTML = apps.map(app => `
+      <a class="app-card" href="${app.url}" target="_blank" rel="noopener noreferrer">
+        <div class="app-card-head">
+          <span class="app-card-name">${app.name}</span>
+          <span class="log-tag">${app.platform}</span>
+        </div>
+        <p class="app-card-tagline">${app.tagline}</p>
+      </a>
     `).join('');
   }
 

--- a/main.js
+++ b/main.js
@@ -37,21 +37,13 @@ class MithaharaApp {
     const contactGrid = document.querySelector('.contact-grid');
     if (!contactGrid) return;
 
-    const contactEntries = [
-      { type: 'email', label: 'Email', value: contacts.email },
-    ];
-
-    contactGrid.innerHTML = contactEntries.map(contact => `
-      <div class="contact-item">
-        <div class="contact-icon">${this.getIconForType(contact.type)}</div>
-        <h3 class="contact-label">${contact.label}</h3>
-        <div class="contact-details">
-          ${Array.isArray(contact.value)
-            ? contact.value.map(v => `<p>${v}</p>`).join('')
-            : `<p>${contact.value}</p>`}
-        </div>
+    contactGrid.innerHTML = `
+      <div class="contact-card">
+        <span class="contact-email">${contacts.email}</span>
+        <div class="contact-address">${contacts.address}</div>
+        <a class="contact-whatsapp" href="${contacts.whatsapp}" target="_blank" rel="noopener noreferrer">→ join our WhatsApp channel</a>
       </div>
-    `).join('');
+    `;
   }
 
   renderFAQ() {
@@ -61,7 +53,8 @@ class MithaharaApp {
     faqList.innerHTML = faqs.map((faq, index) => `
       <div class="faq-item">
         <button class="faq-question" data-index="${index}">
-          <span>${faq.question}</span>
+          <span class="q-tag">Q</span>
+          <span class="faq-question-text">${faq.question}</span>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer" id="faq-answer-${index}">
@@ -96,13 +89,6 @@ class MithaharaApp {
         }
       });
     });
-  }
-
-  getIconForType(type) {
-    const icons = {
-      email: '✉️'
-    };
-    return icons[type] || '•';
   }
 }
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://mithahara.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://mithahara.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/style.css
+++ b/style.css
@@ -1,15 +1,21 @@
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Inter:wght@300;400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Spectral:wght@500;600;700&family=Archivo:wght@400;500;600&family=Space+Mono:wght@400;700&display=swap');
 
 :root {
-  --primary-color: #2D5A43;
-  --secondary-color: #E89B75;
-  --bg-color: #FDFCF8;
-  --surface-color: #FFFFFF;
-  --text-main: #1C1C1C;
-  --text-muted: #575757;
-  --border-light: #E8E4D9;
-  --font-serif: 'Playfair Display', serif;
-  --font-sans: 'Inter', sans-serif;
+  --moss: #337958;
+  --moss-dark: #295F45;
+  --ink: #201D15;
+  --sand: #F6F1E2;
+  --sand-card: #F2ECD8;
+  --border-sand: #E0D8B8;
+  --gold: #E89B75;
+  --gold-text: #B5502E;
+  --text-muted: #565042;
+  --footer-bg: #201D15;
+  --footer-text: #F6F1E2;
+  --footer-muted: #B7AE90;
+  --font-serif: 'Spectral', serif;
+  --font-sans: 'Archivo', sans-serif;
+  --font-mono: 'Space Mono', monospace;
   --space-lg: 5rem;
   --space-md: 2.5rem;
   --space-sm: 1.25rem;
@@ -21,17 +27,28 @@
 
 body {
   font-family: var(--font-sans);
-  background-color: var(--bg-color);
-  color: var(--text-main);
+  background-color: var(--sand);
+  color: var(--ink);
   line-height: 1.7;
   margin: 0;
   -webkit-font-smoothing: antialiased;
 }
 
+body::after {
+  content: '';
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 4px;
+  height: 100%;
+  background: var(--gold);
+  z-index: 999;
+  pointer-events: none;
+}
+
 h1, h2, h3, .nav-title, .hero-title, .section-title, .menu-category-title {
   font-family: var(--font-serif);
   font-weight: 700;
-  font-style: italic;
   margin-bottom: 1.5rem;
 }
 
@@ -39,6 +56,33 @@ h1, h2, h3, .nav-title, .hero-title, .section-title, .menu-category-title {
   max-width: 1100px;
   margin: 0 auto;
   padding: 0 var(--space-sm);
+}
+
+/* --- Log tag: the recurring status/label motif --- */
+.log-tag {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.6rem;
+  background: var(--moss);
+  color: var(--sand);
+  border-radius: 1px;
+  width: fit-content;
+}
+
+.log-tag.gold {
+  background: var(--gold);
+  color: var(--ink);
+}
+
+.log-row {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 /* --- Layout Sections --- */
@@ -50,11 +94,11 @@ section {
   position: fixed;
   top: 0;
   width: 100%;
-  background: rgba(253, 252, 248, 0.95);
+  background: rgba(246, 241, 226, 0.95);
   backdrop-filter: blur(10px);
   z-index: 1000;
   padding: 1.2rem 0;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border-sand);
 }
 
 .nav-container {
@@ -67,10 +111,34 @@ section {
 }
 
 .nav-title {
-  font-size: 1.8rem;
-  color: var(--primary-color);
+  font-size: 1.6rem;
+  color: var(--moss);
   text-decoration: none;
   margin: 0;
+}
+
+.nav-links {
+  display: flex;
+  gap: 2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  color: var(--ink);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.nav-links a:hover {
+  color: var(--gold-text);
+}
+
+@media (max-width: 768px) {
+  .nav-links { display: none; }
 }
 
 .main-content {
@@ -87,97 +155,267 @@ section {
   max-width: 1100px;
   margin: 0 auto;
   padding: 0 var(--space-sm);
-  text-align: center;
+  display: flex;
+  align-items: center;
+  gap: 4rem;
+}
+
+.hero-copy {
+  flex: 1.15;
+  text-align: left;
+}
+
+.hero-cards {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .hero-container { flex-direction: column; }
+  .hero-copy, .hero-cards { text-align: center; width: 100%; }
+  .hero-cards { align-items: stretch; }
 }
 
 .hero-title {
-  font-size: 5rem;
-  color: var(--primary-color);
-  margin-bottom: 0.5rem;
+  font-size: 4.5rem;
+  line-height: 1.02;
+  color: var(--ink);
+  margin: 0.5rem 0 0.25rem;
 }
 
 .hero-subtitle {
-  font-family: var(--font-sans);
-  font-size: 0.8rem;
-  letter-spacing: 0.2em;
-  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--gold-text);
   margin-bottom: 1rem;
 }
 
 .hero-description {
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   color: var(--text-muted);
   margin-bottom: 2rem;
+  max-width: 480px;
 }
 
 .hero-actions {
   display: flex;
-  gap: 1rem;
-  justify-content: center;
+  gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+  .hero-description { max-width: none; }
+  .hero-actions { justify-content: center; }
+}
+
+.venture-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  background: var(--sand-card);
+  border-left: 3px solid var(--moss);
+  text-decoration: none;
+  color: var(--ink);
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.venture-card.upcoming {
+  border-left-color: var(--gold);
 }
 
 /* --- Section Title --- */
 .section-title {
-  font-size: 3rem;
+  font-size: 2.75rem;
   text-align: center;
 }
 
-.menu-tagline {
+.subsection-title {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
   text-align: center;
-  font-size: 0.8rem;
-  letter-spacing: 0.2em;
-  color: var(--text-muted);
+  margin-top: 0;
+}
+
+/* --- Venture Sections (Ahar / Man'sahara / Apps) --- */
+.venture-section .section-title,
+.venture-section .venture-tagline,
+.venture-section .venture-description {
+  text-align: center;
+}
+
+.venture-tagline {
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gold-text);
   margin-top: -1rem;
-  margin-bottom: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.venture-description {
+  max-width: 700px;
+  margin: 0 auto 2rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.teaser-section {
+  background: var(--sand-card);
+  position: relative;
+  overflow: hidden;
+}
+
+.teaser-watermark {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: 16rem;
+  color: var(--ink);
+  opacity: 0.04;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.affiliate-disclosure {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 1rem;
+}
+
+/* --- Apps placeholder slots --- */
+.apps-slots {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  max-width: 700px;
+  margin: 0 auto 2.5rem;
+}
+
+.app-slot {
+  border: 1px dashed var(--border-sand);
+  border-radius: 3px;
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: #A39A7C;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.app-slot .slot-label {
+  color: var(--border-sand);
+}
+
+/* --- Ahar details: FAQ + Contact side by side --- */
+.ahar-details {
+  display: flex;
+  gap: 2.5rem;
+  margin-top: var(--space-md);
+}
+
+.ahar-details > div {
+  flex: 1;
+}
+
+@media (max-width: 768px) {
+  .ahar-details { flex-direction: column; }
 }
 
 /* --- Grid & List Styles --- */
-.contact-grid, .menu-grid, .footer-content {
+.menu-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
   margin-top: 2rem;
 }
 
-.contact-item {
-  text-align: left;
+.contact-card {
+  background: var(--ink);
+  color: var(--sand);
+  padding: 1.5rem 1.75rem;
+  border-radius: 3px;
+  font-size: 0.9rem;
+  line-height: 1.9;
 }
 
-.contact-icon {
-  font-size: 1.5rem;
-  color: var(--primary-color);
-  margin-bottom: 0.75rem;
+.contact-card .contact-email {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--gold);
+  margin-bottom: 0.5rem;
+  display: block;
+}
+
+.contact-card .contact-address {
+  color: var(--footer-muted);
+}
+
+.contact-card .contact-whatsapp {
+  display: block;
+  margin-top: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: #8FC6AE;
+  text-decoration: none;
 }
 
 .faq-list {
-  max-width: 800px;
-  margin: 0 auto;
+  margin: 2rem 0 0;
 }
 
 .faq-item {
-  margin-bottom: 1rem;
-  border-bottom: 1px solid var(--border-light);
+  margin-bottom: 0.75rem;
+  background: var(--sand-card);
+  border-left: 3px solid var(--moss);
 }
 
 .faq-question {
   width: 100%;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 0;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
   background: none;
   border: none;
   cursor: pointer;
-  font-family: var(--font-serif);
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--text-main);
   text-align: left;
 }
 
+.faq-question .q-tag {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--gold-text);
+  flex-shrink: 0;
+}
+
+.faq-question .faq-question-text {
+  flex: 1;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--ink);
+}
+
+.faq-icon {
+  color: var(--text-muted);
+}
+
 .faq-answer {
-  padding-bottom: 1.5rem;
+  padding: 0 1.1rem 1.1rem 2.6rem;
   color: var(--text-muted);
   display: none;
 }
@@ -186,78 +424,162 @@ section {
   display: block;
 }
 
-/* --- Menu & Footer Specifics --- */
+/* --- Menu Specifics --- */
 .menu-category-title {
-  font-size: 2rem;
-  border-bottom: 1px solid var(--border-light);
-  padding-bottom: 0.75rem;
+  font-size: 1.2rem;
+  color: var(--moss);
+  border-bottom: 1px solid var(--border-sand);
+  padding-bottom: 0.6rem;
 }
 
 .menu-item {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  padding: 0.5rem 0;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--border-sand);
+  font-size: 0.9rem;
+}
+
+.menu-item:last-child {
+  border-bottom: none;
 }
 
 .menu-item-name {
-  font-family: var(--font-serif);
-  font-weight: 600;
-  font-style: italic;
+  font-family: var(--font-sans);
+  font-weight: 500;
+}
+
+.menu-item-price {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--gold-text);
+}
+
+/* --- Footer --- */
+.footer {
+  background: var(--footer-bg);
+  color: var(--footer-text);
+}
+
+.footer-content {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 2.5rem;
+  margin-top: 0;
 }
 
 .footer-section {
   text-align: left;
 }
 
+.footer-title {
+  color: var(--footer-text);
+}
+
+.footer-description {
+  color: var(--footer-muted);
+  font-size: 0.9rem;
+}
+
+.footer-subtitle {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 0.75rem;
+}
+
 .footer-links, .footer-links ul {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .footer-links a {
   text-decoration: none;
-  color: var(--text-muted);
+  color: var(--footer-muted);
+  font-size: 0.9rem;
   transition: color 0.2s;
 }
 
 .footer-links a:hover {
-  color: var(--primary-color);
+  color: var(--gold);
 }
 
 .social-links {
   display: flex;
-  gap: 1.25rem;
-  font-size: 1.2rem;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .social-links a {
-  color: var(--primary-color);
+  color: var(--footer-muted);
   text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.social-links a:hover {
+  color: var(--gold);
+}
+
+.footer-bottom {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: #857D63;
+  border-top: 1px solid #38342A;
+  padding-top: 1.25rem;
+  margin-top: 2rem;
+}
+
+@media (max-width: 768px) {
+  .footer-content { grid-template-columns: 1fr; }
 }
 
 /* --- Buttons --- */
 .cta-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem 2rem;
-  background: var(--surface-color);
-  border: 1px solid var(--primary-color);
-  color: var(--primary-color);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 0.75rem;
+  gap: 0.6rem;
+  padding: 0.9rem 1.75rem;
+  border-radius: 3px;
+  text-transform: none;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
   text-decoration: none;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
 }
 
-.cta-button:hover {
-  background: var(--primary-color);
-  color: white;
+.cta-button.primary {
+  background: var(--moss);
+  border: 1px solid var(--moss);
+  color: var(--sand);
+}
+
+.cta-button.primary:hover {
+  background: var(--moss-dark);
+}
+
+.cta-button.secondary {
+  background: transparent;
+  border: 1px solid var(--border-sand);
+  color: var(--ink);
+}
+
+.cta-button.secondary:hover {
+  border-color: var(--moss);
+  color: var(--moss);
+}
+
+.cta-button.large {
+  padding: 1rem 2.25rem;
+  font-size: 0.9rem;
 }
 
 .theme-toggle, .floating-elements {
@@ -265,6 +587,7 @@ section {
 }
 
 @media (max-width: 768px) {
-  .section-title { font-size: 2.5rem; }
-  .hero-title { font-size: 3.5rem; }
+  .section-title { font-size: 2.25rem; }
+  .hero-title { font-size: 3rem; }
+  .teaser-watermark { font-size: 8rem; }
 }

--- a/style.css
+++ b/style.css
@@ -295,29 +295,44 @@ section {
   margin-top: 1rem;
 }
 
-/* --- Apps placeholder slots --- */
-.apps-slots {
+/* --- Apps grid --- */
+.apps-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1rem;
-  max-width: 700px;
+  max-width: 900px;
   margin: 0 auto 2.5rem;
+  text-align: left;
 }
 
-.app-slot {
-  border: 1px dashed var(--border-sand);
-  border-radius: 3px;
-  padding: 1rem;
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: #A39A7C;
+.app-card {
+  background: var(--sand-card);
+  border-left: 3px solid var(--moss);
+  padding: 1.1rem 1.25rem;
+  text-decoration: none;
+  color: var(--ink);
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.5rem;
 }
 
-.app-slot .slot-label {
-  color: var(--border-sand);
+.app-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.app-card-name {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.app-card-tagline {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0;
 }
 
 /* --- Ahar details: FAQ + Contact side by side --- */


### PR DESCRIPTION
## Summary
- Restructures the single-venture site into the Mithahara umbrella covering Ahar (vegetarian food, active), Man'sahara (non-veg, coming soon), and Apps (Chrome extensions + Odoo apps, with Odoo affiliate CTA)
- Applies a full visual redesign ("Field Log" direction: Spectral/Archivo/Space Mono type system, moss/coral brand colors, recurring log-tag motif) in place of the previous generic template look
- Removes phone numbers from the contact card ahead of going global
- Lists the four apps actually shipped (BYOK Gateway, Community Cash Reconciler, Multi-Currency Rounding, ClipMark) as real cards linking to their store listings
- Adds SEO: meta description, canonical URL, Open Graph/Twitter tags, JSON-LD structured data tying Mithahara to each app as creator, robots.txt, sitemap.xml

## Test plan
- [x] `npm run build` succeeds
- [x] Verified in-browser (mobile + desktop): nav anchors, FAQ accordion, menu/contact/footer rendering, all 4 app links resolve to correct store URLs
- [x] JSON-LD validated as parseable JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)